### PR TITLE
TWOFCS Website Info Dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ To register for the Code Showcase, please fill out the form [here](https://peati
 
 ### Abstract Submission
 #### General Information:
-    - Abstract should be no longer than 5 pages
-    - Presentations should be no longer than 15 minutes
-    - Presentations are given 5 minutes of Q&A
-    - Technical talks will be grouped into sessions
-    - Abstract Template Available [here](https://science-tokyo.box.com/s/ukdu5xm1om8jetsmptswxds7bzcan6y3).
+ - Abstract should be no longer than 5 pages
+ - Presentations should be no longer than 15 minutes
+ - Presentations are given 5 minutes of Q&A
+ - Technical talks will be grouped into sessions
+ - Abstract Template Available [here](https://science-tokyo.box.com/s/ukdu5xm1om8jetsmptswxds7bzcan6y3).
 
 #### Potential Topics Include (but are not limited to):
  - Fundamentals of nuclear fuel cycle systems. Modeling. Development of analysis methods, uncertainty assessment, etc.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
 # TWOFCS-2026
 Files and information related to the TWOFCS 2026 conference
+
+## Important Details
+Some important details about the conference at a glance:
+
+### Dates
+| Date                       | Deadline               |
+|----------------------------|------------------------|
+| Sep - Nov 30, 2025         | Abstract Submission    |
+| Nov 1 2025 - Jan 31, 2026  | Early Registration     |
+| Feb 1 - Apr 14, 2026       | Regular Registration   |
+| Apr 15 - Apr 17, 2026      | TWOFCS 2026            |
+| Date to be Announced       | Full Paper Close       |
+
+### Fees
+| Item                       | Fee                    |
+|----------------------------|------------------------|
+| General (Early)            | ¥15,000                |
+| General (Regular)          | ¥20,000                |
+| Student                    | Free                   |
+| Full Paper                 | Coming Soon            |
+
+### Code Showcase Registration
+To register for the Code Showcase, please fill out the form [here](https://peatix.com/us/event/4527366). The form is not available before September 1st, 2025.
+
+### Abstract Submission
+#### General Information:
+    - Abstract should be no longer than 5 pages
+    - Presentations should be no longer than 15 minutes
+    - Presentations are given 5 minutes of Q&A
+    - Technical talks will be grouped into sessions
+    - Abstract Template Available [here](https://science-tokyo.box.com/s/ukdu5xm1om8jetsmptswxds7bzcan6y3).
+
+#### Potential Topics Include (but are not limited to):
+ - Fundamentals of nuclear fuel cycle systems. Modeling. Development of analysis methods, uncertainty assessment, etc.
+ - Code development for nuclear fuel cycle simulators
+ - Analysis of future nuclear energy utilization and nuclear fuel cycles
+ - Policies, economic feasibility, social acceptability, nuclear non-proliferation safeguards, etc., for future nuclear energy utilization
+
+## Overview of the Conference
+The **7th Technical Workshop on Fuel Cycle Simulation (TWoFCS) 2026** will be held jointly with **NuMBAC 2026** in Tokyo, Japan, from **April 15–17, 2026**. This international workshop gathers experts to discuss nuclear and fuel cycle strategies using numerical analysis, integrating both technical and social science perspectives under the theme:
+
+> **"Strategy & Simulation Towards Fuel Cycle 2.0"**
+
+The goal is to design a sustainable nuclear fuel cycle for the anticipated "Second Expansion Phase" of nuclear power.
+
+## Main Activities
+- **Code Showcase** – Live demonstrations of nuclear fuel cycle simulators from around the world.
+- **Plenary Session** – Keynote talks from experts in nuclear energy policy, strategy, and cooperation.
+- **Technical Sessions** – Oral and poster presentations (40–60 expected) on advanced research and applications.
+
+## Additional Information
+- Venue: **Institute of Science Tokyo** (West Building 9)
+- Special event: “Global Kanpai Night” on April 16 (paid entry, fees collected on-site).
+- Contact: [twofcs2026@zc.iir.isct.ac.jp](mailto:twofcs2026@zc.iir.isct.ac.jp)
+- More info: Past events from 2016–2024 [available online](https://peatix.com/us/event/4527366).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TWOFCS-2026
-Files and information related to the TWOFCS 2026 conference
+The **7th Technical Workshop on Fuel Cycle Simulation (TWoFCS) 2026** will be held jointly with **NuMBAC 2026** in Tokyo, Japan, from **April 15–17, 2026**. This international workshop gathers experts to discuss nuclear and fuel cycle strategies using numerical analysis, integrating both technical and social science perspectives under the theme:
+
+> **"Strategy & Simulation Towards Fuel Cycle 2.0"**
+
+The goal is to design a sustainable nuclear fuel cycle for the anticipated "Second Expansion Phase" of nuclear power. The official [conference website](https://peatix.com/us/event/4527366) will always have the most up-to-date information.
 
 ## Important Details
 Some important details about the conference at a glance:
@@ -33,17 +37,10 @@ To register for the Code Showcase, please fill out the form [here](https://peati
  - Abstract Template Available [here](https://science-tokyo.box.com/s/ukdu5xm1om8jetsmptswxds7bzcan6y3).
 
 #### Potential Topics Include (but are not limited to):
- - Fundamentals of nuclear fuel cycle systems. Modeling. Development of analysis methods, uncertainty assessment, etc.
+ - Fundamentals of nuclear fuel cycle systems: modeling, development of analysis methods, uncertainty assessment, etc.
  - Code development for nuclear fuel cycle simulators
  - Analysis of future nuclear energy utilization and nuclear fuel cycles
  - Policies, economic feasibility, social acceptability, nuclear non-proliferation safeguards, etc., for future nuclear energy utilization
-
-## Overview of the Conference
-The **7th Technical Workshop on Fuel Cycle Simulation (TWoFCS) 2026** will be held jointly with **NuMBAC 2026** in Tokyo, Japan, from **April 15–17, 2026**. This international workshop gathers experts to discuss nuclear and fuel cycle strategies using numerical analysis, integrating both technical and social science perspectives under the theme:
-
-> **"Strategy & Simulation Towards Fuel Cycle 2.0"**
-
-The goal is to design a sustainable nuclear fuel cycle for the anticipated "Second Expansion Phase" of nuclear power.
 
 ## Main Activities
 - **Code Showcase** – Live demonstrations of nuclear fuel cycle simulators from around the world.
@@ -54,4 +51,4 @@ The goal is to design a sustainable nuclear fuel cycle for the anticipated "Seco
 - Venue: **Institute of Science Tokyo** (West Building 9)
 - Special event: “Global Kanpai Night” on April 16 (paid entry, fees collected on-site).
 - Contact: [twofcs2026@zc.iir.isct.ac.jp](mailto:twofcs2026@zc.iir.isct.ac.jp)
-- More info: Past events from 2016–2024 [available online](https://peatix.com/us/event/4527366).
+- More info: Past events from 2016–2025 [available online](https://peatix.com/us/event/4527366).


### PR DESCRIPTION
# Summary of Changes

This PR grabs a bunch of the information from the TWOFCS2026 website and adds it to the README.md file in this repo. 

# Related CEPs and Issues

This PR is related to:

N/A

# Associated Developers

ChatGPT

# Design Notes

Note about the use of ChatGPT:

I didn't know how to do tables in markdown, so I had it show me, and then I had it summarize some of the paragraphs in the later sections, since I tend to include too much information when I summarize things. It is important to note, though, that I manually went through and checked all of its summaries. It is possible that I made a mistake, but I'm pretty confident. The `Important Information` section was all manually filled out.
